### PR TITLE
Create new OSE project in Windows script

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -53,6 +53,11 @@ if not "%ERRORLEVEL%" == "0" (
 )
 
 echo.
+echo Creating a new project...
+echo.
+call oc new-project rhcs-brms-install-demo
+
+echo.
 echo Setting up a new build...
 echo.
 call oc new-build "jbossdemocentral/developer" --name=rhcs-brms-install-demo --binary=true


### PR DESCRIPTION
Added omitted project creation step to prevent brms resources from being created in the default project
